### PR TITLE
Updated GoogleDoc class to work with new(er) spreadsheets

### DIFF
--- a/etc/gdocs.py
+++ b/etc/gdocs.py
@@ -27,11 +27,17 @@ class GoogleDoc(object):
     key = None
     file_format = 'xlsx'
     file_name = 'copy'
-    gid = '0'
+    gid = None
 
     # You can change these with kwargs but it's not recommended.
-    spreadsheet_url = 'https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=%(key)s&exportFormat=%(format)s&gid=%(gid)s'
-    new_spreadsheet_url = 'https://docs.google.com/spreadsheets/d/%(key)s/export?format=%(format)s&id=%(key)s&gid=%(gid)s'
+    spreadsheet_url = 'https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=%(key)s&exportFormat=%(format)s'
+    if gid:
+        spreadsheet_url = spreadsheet_url + '&gid=%(gid)s'
+
+    new_spreadsheet_url = 'https://docs.google.com/spreadsheets/d/%(key)s/export?format=%(format)s&id=%(key)s'
+    if gid:
+        new_spreadsheet_url = new_spreadsheet_url + '&gid=%(gid)s'
+
     auth = None
     email = os.environ.get('APPS_GOOGLE_EMAIL', None)
     password = os.environ.get('APPS_GOOGLE_PASS', None)

--- a/fabfile/text.py
+++ b/fabfile/text.py
@@ -11,7 +11,7 @@ import app_config
 from etc.gdocs import GoogleDoc
 
 @task(default=True)
-def update():
+def update(gid=None):
     """
     Downloads a Google Doc as an Excel file.
     """
@@ -24,6 +24,9 @@ def update():
         bits = url.split('key=')
         bits = bits[1].split('&')
         doc['key'] = bits[0]
+
+        if gid:
+            doc['gid'] = gid
 
         g = GoogleDoc(**doc)
         g.get_auth()


### PR DESCRIPTION
I noticed the `gid` parameter is ignored when fetching the example spreadsheet included with the app template. However, the `gid` parameter does work when fetching newer spreadsheets.

So, I changed the `GoogleDoc` class to omit the `gid` param so that all sheets in a spreadsheet will be downloaded by default. Also changed the `fab text.update` command to accept a `gid` argument in case you only want to fetch a specific sheet from your spreadsheet.
