### PR TITLE
use the app's view_functions dict to find the view to render

### DIFF
--- a/fabfile/render.py
+++ b/fabfile/render.py
@@ -105,19 +105,10 @@ def render_all():
             g.compile_includes = True
             g.compiled_includes = compiled_includes
 
-            bits = name.split('.')
-
-            # Determine which module the view resides in
-            if len(bits) > 1:
-                module, name = bits
-            else:
-                module = 'app'
-
-            view = globals()[module].__dict__[name]
+            view = app.app.view_functions[name]
             content = view()
 
             compiled_includes = g.compiled_includes
 
         with open(filename, 'w') as f:
             f.write(content.encode('utf-8'))
-


### PR DESCRIPTION
I changed `render_all` to use a more reliable way of looking up view functions.

Essentially what this does is avoid a `KeyError` when using named endpoints. For example:

```
@app.route('/test/', endpoint='some-name')
def test_view():
    ...
```

Where `endpoint` differs from the view function name.

This works because `app.app.view_functions` is a dict with keys that correspond to the `endpoint` attribute of each of the app's routes.

Versus `globals()[module].__dict__` which has keys for view function names only.

Works with every method of adding routes that I could think of.
